### PR TITLE
Add 'beta' property to fugue_aws_types

### DIFF
--- a/docs/data-sources/aws_types.md
+++ b/docs/data-sources/aws_types.md
@@ -26,6 +26,7 @@ data "fugue_aws_types" "all" {
 - **govcloud** (Boolean)
 - **id** (String) The ID of this resource.
 - **region** (String)
+- **beta** (Boolean) Whether to include beta resources, default false.
 
 ### Read-Only
 

--- a/fugue/data_source_aws_types.go
+++ b/fugue/data_source_aws_types.go
@@ -33,6 +33,11 @@ func dataSourceAwsTypes() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"beta": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -54,6 +59,10 @@ func dataSourceAwsTypesRead(ctx context.Context, d *schema.ResourceData, m inter
 		regionForTypes = region.(string)
 	}
 	params.Region = &regionForTypes
+
+	if val := d.Get("beta").(bool); val {
+		params.BetaResources = &val
+	}
 
 	var typeMetadata *models.ResourceTypeMetadata
 


### PR DESCRIPTION
This flag controls whether or not the beta_resources flag should be set when calling the API to list supported resource types.

To test, just change the examples/main.tf to include `beta = true` in the `fugue_aws_types`.

It might be preferable to call the parameter "beta_resources" instead of just "beta"; I don't have a preference, but obviously it's a trivial change if you prefer "beta_resources".