### PR TITLE
[CLOUD-147] gracefully handle removal of resources

### DIFF
--- a/fugue/resource_aws_environment.go
+++ b/fugue/resource_aws_environment.go
@@ -193,6 +193,14 @@ func resourceAwsEnvironmentRead(ctx context.Context, d *schema.ResourceData, m i
 		env = resp.Payload
 		return nil
 	})
+
+	// If the resource is not found, remove it from local terraform state
+	target := &environments.GetEnvironmentNotFound{}
+	if errors.As(err, &target) {
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -347,6 +355,14 @@ func resourceAwsEnvironmentDelete(ctx context.Context, d *schema.ResourceData, m
 		}
 		return nil
 	})
+
+	// If the resource is not found, remove it from local terraform state
+	target := &environments.DeleteEnvironmentNotFound{}
+	if errors.As(err, &target) {
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/fugue/resource_azure_environment.go
+++ b/fugue/resource_azure_environment.go
@@ -2,6 +2,7 @@ package fugue
 
 import (
 	"context"
+	"errors"
 	"log"
 	"sort"
 
@@ -182,6 +183,14 @@ func resourceAzureEnvironmentRead(ctx context.Context, d *schema.ResourceData, m
 		env = resp.Payload
 		return nil
 	})
+
+	// If the resource is not found, remove it from local terraform state
+	target := &environments.GetEnvironmentNotFound{}
+	if errors.As(err, &target) {
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -307,6 +316,14 @@ func resourceAzureEnvironmentDelete(ctx context.Context, d *schema.ResourceData,
 		}
 		return nil
 	})
+
+	// If the resource is not found, remove it from local terraform state
+	target := &environments.DeleteEnvironmentNotFound{}
+	if errors.As(err, &target) {
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/fugue/resource_family.go
+++ b/fugue/resource_family.go
@@ -2,6 +2,7 @@ package fugue
 
 import (
 	"context"
+	"errors"
 
 	"github.com/fugue/fugue-client/client/families"
 	"github.com/fugue/fugue-client/models"
@@ -126,6 +127,14 @@ func resourceFamilyRead(ctx context.Context, d *schema.ResourceData, m interface
 		family = resp.Payload
 		return nil
 	})
+
+	// If the resource is not found, remove it from local terraform state
+	target := &families.GetFamilyNotFound{}
+	if errors.As(err, &target) {
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/fugue/resource_google_environment.go
+++ b/fugue/resource_google_environment.go
@@ -2,6 +2,7 @@ package fugue
 
 import (
 	"context"
+	"errors"
 	"log"
 	"sort"
 
@@ -159,6 +160,14 @@ func resourceGoogleEnvironmentRead(ctx context.Context, d *schema.ResourceData, 
 		env = resp.Payload
 		return nil
 	})
+
+	// If the resource is not found, remove it from local terraform state
+	target := &environments.GetEnvironmentNotFound{}
+	if errors.As(err, &target) {
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -274,6 +283,14 @@ func resourceGoogleEnvironmentDelete(ctx context.Context, d *schema.ResourceData
 		}
 		return nil
 	})
+
+	// If the resource is not found, remove it from local terraform state
+	target := &environments.DeleteEnvironmentNotFound{}
+	if errors.As(err, &target) {
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/fugue/resource_notification.go
+++ b/fugue/resource_notification.go
@@ -2,6 +2,7 @@ package fugue
 
 import (
 	"context"
+	"errors"
 	"log"
 
 	"github.com/fugue/fugue-client/client/notifications"
@@ -176,8 +177,10 @@ func resourceNotificationRead(ctx context.Context, d *schema.ResourceData, m int
 	if diags != nil {
 		return diags
 	}
+	// If the resource is not found, remove it from local terraform state
 	if notification == nil {
-		return diag.Errorf("Unable to locate notification with id '%s'.", d.Id())
+		d.SetId("")
+		return nil
 	}
 	if err := d.Set("name", notification.Name); err != nil {
 		return diag.FromErr(err)
@@ -276,6 +279,14 @@ func resourceNotificationDelete(ctx context.Context, d *schema.ResourceData, m i
 		}
 		return nil
 	})
+
+	// If the resource is not found, remove it from local terraform state
+	target := &notifications.DeleteNotificationNotFound{}
+	if errors.As(err, &target) {
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/fugue/resource_rule.go
+++ b/fugue/resource_rule.go
@@ -2,6 +2,7 @@ package fugue
 
 import (
 	"context"
+	"errors"
 
 	"github.com/fugue/fugue-client/client/custom_rules"
 	"github.com/fugue/fugue-client/models"
@@ -139,6 +140,14 @@ func resourceRuleRead(ctx context.Context, d *schema.ResourceData, m interface{}
 		rule = resp.Payload
 		return nil
 	})
+
+	// If the resource is not found, remove it from local terraform state
+	target := &custom_rules.GetCustomRuleNotFound{}
+	if errors.As(err, &target) {
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/fugue/resource_rule_waiver.go
+++ b/fugue/resource_rule_waiver.go
@@ -2,6 +2,7 @@ package fugue
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/fugue/fugue-client/client/rule_waivers"
@@ -171,6 +172,14 @@ func resourceRuleWaiverRead(ctx context.Context, d *schema.ResourceData, m inter
 		waiver = resp.Payload
 		return nil
 	})
+
+	// If the resource is not found, remove it from local terraform state
+	target := &rule_waivers.GetRuleWaiverNotFound{}
+	if errors.As(err, &target) {
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -265,6 +274,14 @@ func resourceRuleWaiverDelete(ctx context.Context, d *schema.ResourceData, m int
 		}
 		return nil
 	})
+
+	// If the resource is not found, remove it from local terraform state
+	target := &rule_waivers.GetRuleWaiverNotFound{}
+	if errors.As(err, &target) {
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
When resources are removed outside of terraform, reading their state results in a 404, which causes the terraform action to fail. This PR removes the resource form terraform local state when these 404s occur. This allows the resource to be recreated if it still exists in the plan.